### PR TITLE
feat: jpa 테이블 이름 설정을 대문자도 인식할 수 있게 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
## 1. 무엇을?

<br> 
application.yml 파일의 jpa 설정을 추가했습니다

## 2. 상세 설명

<br>
기존에는 데이터베이스 테이블에 매핑 할 경우 테이블 명을 모두 소문자로 인식했음 
application.yml 에 설정을 추가하여 해결함

## 3. 추가 사항


<br>

