### PR TITLE
Feat/#7/액세스시 토큰을 확인하고 재 발급 받는 기능 추가

### DIFF
--- a/src/main/java/DDuDu/DDuDu/config/WebSecurityConfig.java
+++ b/src/main/java/DDuDu/DDuDu/config/WebSecurityConfig.java
@@ -1,4 +1,11 @@
 package DDuDu.DDuDu.config;
+
+import DDuDu.DDuDu.config.jwt.JwtProperties;
+import DDuDu.DDuDu.config.jwt.JwtTokenFilter;
+import DDuDu.DDuDu.config.jwt.TokenProvider;
+import DDuDu.DDuDu.repository.RefreshTokenRepository;
+import DDuDu.DDuDu.repository.UserRepository;
+import DDuDu.DDuDu.service.TokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,12 +16,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @Configuration
 public class WebSecurityConfig {
 
     private final UserDetailService userService;
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -23,13 +33,14 @@ public class WebSecurityConfig {
                 .httpBasic().disable()
                 .authorizeRequests(request ->
                         request.requestMatchers(
-                                "/login/**",
-                                "/signup/**",
-                                "/exception/**",
-                                "/items/**")
+                                        "/login/**",
+                                        "/signup/**",
+                                        "/exception/**",
+                                        "/items/**")
                                 .permitAll()
                                 .anyRequest().authenticated()
                 )
+                .addFilterBefore(new JwtTokenFilter(tokenProvider, userRepository), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
@@ -43,8 +54,7 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder()
-    {
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 

--- a/src/main/java/DDuDu/DDuDu/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/DDuDu/DDuDu/config/jwt/JwtTokenFilter.java
@@ -1,5 +1,11 @@
 package DDuDu.DDuDu.config.jwt;
 
+import DDuDu.DDuDu.domain.User;
+import DDuDu.DDuDu.repository.RefreshTokenRepository;
+import DDuDu.DDuDu.repository.UserRepository;
+import DDuDu.DDuDu.service.TokenService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,36 +16,51 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 // OncePerRequestFilter : 매번 들어갈 때 마다 체크 해주는 필터
 @RequiredArgsConstructor
 public class JwtTokenFilter extends OncePerRequestFilter {
-    private final static String HEADER_AUTHORIZATION = "Authorization";
-    private final static String TOKEN_PREFIX = "Bearer ";
+
+    private static final List<String> IGNORE_JWT_FILTER_API = List.of(
+            "/login/token",
+            "/user/refresh",
+            "/admin/login",
+            "/admin/refresh"
+    );
     private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+        if (IGNORE_JWT_FILTER_API.contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String accessToken = tokenProvider.resolveAccessToken(request);
+        String refreshToken = tokenProvider.resolveRefreshToken(request);
 
-        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
-        String token = getAccessToken(authorizationHeader);
-
-        if (token != null && tokenProvider.validToken(token)) {
-            Authentication authentication = tokenProvider.getAuthentication(token);
+        if (accessToken != null && tokenProvider.validToken(accessToken)) {
+            Authentication authentication = tokenProvider.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else if (tokenProvider.validToken(refreshToken)) {
+            Long userId = tokenProvider.getUserId(refreshToken);
+            String newAccessToken = tokenProvider.generateToken(userRepository.findById(userId).get(), "Access");
+            this.setAuthentication(newAccessToken);
+            tokenProvider.setHeaderAccessToken(response, newAccessToken);
+            filterChain.doFilter(request, response);
+        } else {
+            response.setHeader("Response", "expiredToken");
         }
         filterChain.doFilter(request, response);
     }
 
-    private String getAccessToken(String authorizationHeader) {
-
-        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
-            return authorizationHeader.substring(TOKEN_PREFIX.length());
-        }
-
-        return null;
+    public void setAuthentication(String token) {
+        // 토큰으로부터 유저 정보를 받아옵니다.
+        Authentication authentication = tokenProvider.getAuthentication(token);
+        // SecurityContext 에 Authentication 객체를 저장합니다.
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
-
 }

--- a/src/main/java/DDuDu/DDuDu/controller/UserController.java
+++ b/src/main/java/DDuDu/DDuDu/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
         return ResponseEntity.ok(userService.checkEmailDuplicate(email));
     }
 
-    @GetMapping("/signup/username-check//{username}")//사용자 이름 중복 요청시 발생하는 메서드
+    @GetMapping("/signup/username-check/{username}")//사용자 이름 중복 요청시 발생하는 메서드
     public ResponseEntity<Boolean> checkUsernameDuplicate(@PathVariable String username) {
         return ResponseEntity.ok(userService.checkUsernameDuplicate(username));
     }

--- a/src/main/java/DDuDu/DDuDu/controller/UserController.java
+++ b/src/main/java/DDuDu/DDuDu/controller/UserController.java
@@ -45,5 +45,4 @@ public class UserController {
             return ResponseEntity.status(500).body("Internal server error");
         }
     }
-
 }

--- a/src/main/java/DDuDu/DDuDu/repository/RefreshTokenRepository.java
+++ b/src/main/java/DDuDu/DDuDu/repository/RefreshTokenRepository.java
@@ -12,7 +12,10 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUserId(Long userid);
+
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    boolean existsByRefreshToken(String token);
 
     @Modifying
     @Transactional

--- a/src/main/java/DDuDu/DDuDu/repository/UserRepository.java
+++ b/src/main/java/DDuDu/DDuDu/repository/UserRepository.java
@@ -3,12 +3,17 @@ package DDuDu.DDuDu.repository;
 import DDuDu.DDuDu.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findById(Long id);
+
     boolean existsByEmail(String email);
+
     boolean existsByUsername(String username);
 }

--- a/src/main/java/DDuDu/DDuDu/service/UserService.java
+++ b/src/main/java/DDuDu/DDuDu/service/UserService.java
@@ -1,6 +1,5 @@
 package DDuDu.DDuDu.service;
 
-import DDuDu.DDuDu.config.WebSecurityConfig;
 import DDuDu.DDuDu.config.jwt.TokenProvider;
 import DDuDu.DDuDu.domain.RefreshToken;
 import DDuDu.DDuDu.domain.User;
@@ -9,7 +8,6 @@ import DDuDu.DDuDu.repository.RefreshTokenRepository;
 import DDuDu.DDuDu.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,7 +18,6 @@ import java.util.Optional;
 @Service
 @Transactional
 public class UserService {
-    @Autowired
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -44,7 +41,7 @@ public class UserService {
     }
 
     @Transactional
-    public LoginResponse loginService(LoginRequest request) throws Exception {
+    public LoginResponse loginService(LoginRequest request) {
 
 
         User user = userRepository.findByEmail(request.getEmail()).orElseThrow(() ->
@@ -69,7 +66,6 @@ public class UserService {
                 .refreshToken(refreshToken.getRefreshToken())
                 .accessToken(tokenProvider.generateToken(user, "Access"))
                 .build();
-
     }
 
     public User findById(Long id) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

액세스 토큰을 재 발급 받는 로직을 추가하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

1. JwtTokenFilter가 실행 되지 않는 이슈가 있었으나 WebSecurityConfig의 addFilterBefore를 추가하여 해결하였습니다.
2. 만료된 리프레시 토큰을 재 발급 받는 기능을 추가하려고 했으나 만료된 어떤 토큰에서도 parsing이 가능하지 않아 리프레시 토큰은 만료 시 다시 로그인을 요구하는 방식으로 변경 하였습니다.

## 3. 관련 스크린샷을 첨부해주세요.

<br>

<img width="606" alt="스크린샷 2023-11-12 오후 9 26 22" src="https://github.com/Leets-Official/DDuDu-BE/assets/92284769/ea3a8e87-3421-431a-9c5c-8670ef9ad985">





<img width="1164" alt="스크린샷 2023-11-12 오후 9 26 04" src="https://github.com/Leets-Official/DDuDu-BE/assets/92284769/4e8950e3-12a6-41d8-8d07-8a73182e1141">



## 4. 완료 사항

<br>

만료된 액세스 토큰을 재 발급하는 기능을 추가

## 5. 추가 사항

TokenProvider의 resolveAccessToken, getUserId 메서드를 통해 토큰에서 userId를 얻을 수 있습니다. 
