### PR TITLE
Fix/#10/회원가입 시 중복 검사 요청방식 변경

### DIFF
--- a/src/main/java/DDuDu/DDuDu/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/DDuDu/DDuDu/config/jwt/JwtTokenFilter.java
@@ -25,8 +25,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private static final List<String> IGNORE_JWT_FILTER_API = List.of(
             "/login",
             "/signup",
-            "/signup/email-check/{email}",
-            "/signup/username-check/{username}"
+            "/signup/email-check"
     );
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;

--- a/src/main/java/DDuDu/DDuDu/controller/UserController.java
+++ b/src/main/java/DDuDu/DDuDu/controller/UserController.java
@@ -25,14 +25,9 @@ public class UserController {
         }
     }
 
-    @GetMapping("/signup/email-check/{email}")//email 중복 요청시 발생하는 메서드
-    public ResponseEntity<Boolean> checkEmailDuplicate(@PathVariable String email) {
-        return ResponseEntity.ok(userService.checkEmailDuplicate(email));
-    }
-
-    @GetMapping("/signup/username-check/{username}")//사용자 이름 중복 요청시 발생하는 메서드
-    public ResponseEntity<Boolean> checkUsernameDuplicate(@PathVariable String username) {
-        return ResponseEntity.ok(userService.checkUsernameDuplicate(username));
+    @PostMapping("/signup/email-check")//email 중복 요청시 발생하는 메서드
+    public ResponseEntity<Boolean> checkEmailDuplicate(@RequestBody CheckDuplicateRequest checkDuplicateRequest) {
+        return ResponseEntity.ok(userService.checkEmailDuplicate(checkDuplicateRequest));
     }
 
     @PostMapping("/login")

--- a/src/main/java/DDuDu/DDuDu/domain/User.java
+++ b/src/main/java/DDuDu/DDuDu/domain/User.java
@@ -26,7 +26,7 @@ public class User implements UserDetails {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "username", nullable = false, unique = true, length = 10)
+    @Column(name = "username", nullable = false, length = 10)
     private String username;
 
     @Builder
@@ -42,11 +42,13 @@ public class User implements UserDetails {
 
         return this;
     }
+
     public User updateEmail(String email) {
         this.email = email;
 
         return this;
     }
+
     public User updatePassword(String password) {
         this.password = password;
 

--- a/src/main/java/DDuDu/DDuDu/dto/CheckDuplicateRequest.java
+++ b/src/main/java/DDuDu/DDuDu/dto/CheckDuplicateRequest.java
@@ -1,0 +1,10 @@
+package DDuDu.DDuDu.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckDuplicateRequest {
+    private String email;
+}

--- a/src/main/java/DDuDu/DDuDu/service/UserService.java
+++ b/src/main/java/DDuDu/DDuDu/service/UserService.java
@@ -23,8 +23,8 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final BCryptPasswordEncoder encoder;
 
-    public boolean checkEmailDuplicate(String email) {
-        return userRepository.existsByEmail(email); //전달된 email이 저장되어있는지 여부를 boolean으로 리턴
+    public boolean checkEmailDuplicate(CheckDuplicateRequest dto) {
+        return userRepository.existsByEmail(dto.getEmail()); //전달된 email이 저장되어있는지 여부를 boolean으로 리턴
     }
 
     public boolean checkUsernameDuplicate(String username) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

회원가입 시 중복검사 요청방식을 변경하였습니다.
유저의 이름은 고유하지 않아도 되어 중복 검사기능을 제외하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

유저의 이름을 고유하지 않게 수정하는 과정에서 db의 username 설정이 unique 할 경우 오류가 생겨 unique 설정을 해제 해 주었습니다,

## 3. 관련 스크린샷을 첨부해주세요.

<br>

<img width="737" alt="스크린샷 2023-11-14 오후 11 45 42" src="https://github.com/Leets-Official/DDuDu-BE/assets/92284769/e4b07751-e779-4d16-b8f4-0c726c7baefb">

## 4. 완료 사항

<br>

회원가입 시 중복검사 요청방식을 변경
유저의 이름은 고유하지 않아도 되어 중복 검사기능을 제외
